### PR TITLE
[BUGFIX] Modifier le chemin d'accès à composer pour l'installation d'aws-sdk-php

### DIFF
--- a/bin/utils/scalingo-composer-requirement.json
+++ b/bin/utils/scalingo-composer-requirement.json
@@ -14,7 +14,7 @@
       "nginx-includes": [],
       "log-files": [],
       "compile": [
-        "composer require aws/aws-sdk-php"
+        "bin/composer require aws/aws-sdk-php"
       ],
       "new-relic": false,
       "access-log-format": ""


### PR DESCRIPTION
## :unicorn: Problème
`composer` n'est pas/plus directement accessible à la racine du `php-buildpack` ce qui cause l'échec du déploiement de PrivateBin. 

## :robot: Proposition
Mettre à jour le chemin d'accès à `composer`.

## :100: Pour tester
La correction a été testée grâce à un fork du repo.
