### PR TITLE
[TECH] Augmenter la limite des éléments à 100Mb

### DIFF
--- a/bin/utils/custom-conf.php
+++ b/bin/utils/custom-conf.php
@@ -35,7 +35,7 @@ defaultformatter = "plaintext"
 ; syntaxhighlightingtheme = "sons-of-obsidian"
 
 ; size limit per paste or comment in bytes, defaults to 10 Mebibytes
-sizelimit = 10485760
+sizelimit = 104857600
 
 ; template to include, default is "bootstrap" (tpl/bootstrap.php)
 template = "bootstrap"


### PR DESCRIPTION
## 🌸 Problème

Par défaut on ne peut pas mettre d'éléments de plus de 10MB. Or, on en a besoin pour des gros csv ou autre.

## 🌳 Proposition

Modifier la limite pour 100Mb.